### PR TITLE
Add interest-level filters to job tracker columns

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -26,6 +26,10 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+type InterestFilter = "All" | (typeof INTEREST_LEVELS)[number];
+
+const FILTER_OPTIONS: InterestFilter[] = ["All", ...INTEREST_LEVELS];
+
 function KanbanColumn({
   status,
   prospects,
@@ -35,10 +39,19 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
+  const columnSlug = status.replace(/\s+/g, "-").toLowerCase();
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${columnSlug}`}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
@@ -46,11 +59,32 @@ function KanbanColumn({
         <Badge
           variant="secondary"
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          data-testid={`badge-count-${columnSlug}`}
         >
-          {prospects.length}
+          {interestFilter === "All"
+            ? prospects.length
+            : `${filteredProspects.length}/${prospects.length}`}
         </Badge>
       </div>
+
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border/30">
+        {FILTER_OPTIONS.map((option) => (
+          <button
+            key={option}
+            onClick={() => setInterestFilter(option)}
+            data-testid={`filter-${columnSlug}-${option.toLowerCase()}`}
+            className={[
+              "text-[10px] px-2 py-0.5 rounded-full font-medium transition-colors",
+              interestFilter === option
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted",
+            ].join(" ")}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
           {isLoading ? (
@@ -58,12 +92,17 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+          ) : filteredProspects.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center py-8 text-center"
+              data-testid={`empty-${columnSlug}`}
+            >
+              <p className="text-xs text-muted-foreground">
+                {prospects.length > 0 ? "No matches for this filter" : "No prospects"}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}

--- a/server/__tests__/interest-filter.test.ts
+++ b/server/__tests__/interest-filter.test.ts
@@ -1,0 +1,67 @@
+import type { Prospect } from "@shared/schema";
+
+function filterByInterest(
+  prospects: Prospect[],
+  filter: "All" | "High" | "Medium" | "Low",
+): Prospect[] {
+  if (filter === "All") return prospects;
+  return prospects.filter((p) => p.interestLevel === filter);
+}
+
+const makeProspect = (id: number, interestLevel: string): Prospect => ({
+  id,
+  companyName: `Company ${id}`,
+  roleTitle: "Engineer",
+  jobUrl: null,
+  status: "Applied",
+  interestLevel,
+  notes: null,
+  createdAt: new Date(),
+});
+
+const prospects: Prospect[] = [
+  makeProspect(1, "High"),
+  makeProspect(2, "High"),
+  makeProspect(3, "Medium"),
+  makeProspect(4, "Low"),
+  makeProspect(5, "Low"),
+];
+
+describe("interest level column filter", () => {
+  test("All returns every prospect", () => {
+    expect(filterByInterest(prospects, "All")).toHaveLength(5);
+  });
+
+  test("High returns only High-interest prospects", () => {
+    const result = filterByInterest(prospects, "High");
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.interestLevel === "High")).toBe(true);
+  });
+
+  test("Medium returns only Medium-interest prospects", () => {
+    const result = filterByInterest(prospects, "Medium");
+    expect(result).toHaveLength(1);
+    expect(result[0].interestLevel).toBe("Medium");
+  });
+
+  test("Low returns only Low-interest prospects", () => {
+    const result = filterByInterest(prospects, "Low");
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.interestLevel === "Low")).toBe(true);
+  });
+
+  test("returns empty array when no prospects match the filter", () => {
+    const highOnly = [makeProspect(1, "High")];
+    expect(filterByInterest(highOnly, "Low")).toHaveLength(0);
+  });
+
+  test("All on empty array returns empty array", () => {
+    expect(filterByInterest([], "All")).toHaveLength(0);
+  });
+
+  test("filter does not mutate the original array", () => {
+    const original = [...prospects];
+    filterByInterest(prospects, "High");
+    expect(prospects).toHaveLength(original.length);
+  });
+});


### PR DESCRIPTION
Introduces client-side filtering by interest level within each Kanban column, with a new test suite for the filtering logic in `server/__tests__/interest-filter.test.ts` and updates to `client/src/pages/home.tsx` for UI and state management.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 6074ffe3-d86b-4ea5-862a-11bd744cc442
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: ea2bbcbc-4c56-4275-8dd5-31c5338e9a72
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/a4f1a2c9-30f2-480b-b2f7-9769f03daa57/6074ffe3-d86b-4ea5-862a-11bd744cc442/TpE59C2
Replit-Helium-Checkpoint-Created: true