### PR TITLE
Add target salary field to job prospects and display on cards

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -23,7 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2 } from "lucide-react";
+import { Loader2, DollarSign } from "lucide-react";
 
 export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
   const { toast } = useToast();
@@ -37,6 +37,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       notes: "",
+      targetSalary: null,
     },
   });
 
@@ -99,6 +100,34 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
                   value={field.value ?? ""}
                   data-testid="input-job-url"
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <DollarSign className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+                  <Input
+                    type="number"
+                    min={1}
+                    step={1}
+                    placeholder="120000"
+                    className="pl-7"
+                    data-testid="input-target-salary"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(e.target.value === "" ? null : e.target.valueAsNumber)
+                    }
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -23,7 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2 } from "lucide-react";
+import { Loader2, DollarSign } from "lucide-react";
 
 interface EditProspectFormProps {
   prospect: Prospect;
@@ -42,6 +42,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
+      targetSalary: prospect.targetSalary ?? null,
     },
   });
 
@@ -103,6 +104,34 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
                   value={field.value ?? ""}
                   data-testid="input-edit-job-url"
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <DollarSign className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+                  <Input
+                    type="number"
+                    min={1}
+                    step={1}
+                    placeholder="120000"
+                    className="pl-7"
+                    data-testid="input-edit-target-salary"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(e.target.value === "" ? null : e.target.valueAsNumber)
+                    }
+                  />
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,15 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.targetSalary != null && (
+            <span
+              className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+              data-testid={`text-salary-${prospect.id}`}
+            >
+              <DollarSign className="w-3 h-3" />
+              {prospect.targetSalary.toLocaleString("en-US")}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/server/__tests__/interest-filter.test.ts
+++ b/server/__tests__/interest-filter.test.ts
@@ -16,6 +16,7 @@ const makeProspect = (id: number, interestLevel: string): Prospect => ({
   status: "Applied",
   interestLevel,
   notes: null,
+  targetSalary: null,
   createdAt: new Date(),
 });
 

--- a/server/__tests__/salary-validation.test.ts
+++ b/server/__tests__/salary-validation.test.ts
@@ -1,0 +1,109 @@
+import { validateProspect } from "../prospect-helpers";
+import { insertProspectSchema } from "@shared/schema";
+
+describe("target salary validation (prospect-helpers)", () => {
+  test("accepts a valid positive integer salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      targetSalary: 120000,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts null salary (salary is optional)", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      targetSalary: null,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts when salary is omitted entirely", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects zero salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      targetSalary: 0,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects negative salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      targetSalary: -50000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects a decimal salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      targetSalary: 99.99,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+});
+
+describe("target salary validation (Zod schema)", () => {
+  const base = {
+    companyName: "Acme",
+    roleTitle: "Engineer",
+    status: "Bookmarked" as const,
+    interestLevel: "Medium" as const,
+  };
+
+  test("coerces a numeric string to a number", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: "120000" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.targetSalary).toBe(120000);
+  });
+
+  test("coerces empty string to null", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: "" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.targetSalary).toBeNull();
+  });
+
+  test("coerces undefined to null", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: undefined });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.targetSalary).toBeNull();
+  });
+
+  test("fails when salary is 0", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("fails when salary is negative", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("passes when salary is a positive integer", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: 95000 });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.targetSalary).toBe(95000);
+  });
+
+  test("passes when salary is null explicitly", () => {
+    const result = insertProspectSchema.safeParse({ ...base, targetSalary: null });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.targetSalary).toBeNull();
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,13 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.targetSalary !== undefined && data.targetSalary !== null) {
+    const salary = Number(data.targetSalary);
+    if (!Number.isInteger(salary) || salary <= 0) {
+      errors.push("Salary must be a positive whole number");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,13 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
+    if (body.targetSalary !== undefined) {
+      const salary = body.targetSalary === null ? null : Number(body.targetSalary);
+      if (salary !== null && (!Number.isInteger(salary) || salary <= 0)) {
+        return res.status(400).json({ message: "Salary must be a positive whole number" });
+      }
+      updates.targetSalary = salary;
+    }
 
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -22,6 +22,7 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  targetSalary: integer("target_salary"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -35,6 +36,10 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  targetSalary: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
+    z.number().int().positive("Salary must be a positive whole number").nullable().optional(),
+  ),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Adds a new `targetSalary` field to the `prospects` table and schema, including input fields in the Add/Edit Prospect forms, display logic on the ProspectCard, and validation in `prospect-helpers.ts` and `drizzle-zod` schema. Includes new tests in `salary-validation.test.ts`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 6074ffe3-d86b-4ea5-862a-11bd744cc442
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 7153d858-3433-485f-89f1-3dbb9100f842
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/a4f1a2c9-30f2-480b-b2f7-9769f03daa57/6074ffe3-d86b-4ea5-862a-11bd744cc442/cQSfJUN
Replit-Helium-Checkpoint-Created: true